### PR TITLE
Require at least one character in unquoted text

### DIFF
--- a/grammar.ebnf
+++ b/grammar.ebnf
@@ -25,9 +25,9 @@ pattern              ::= unquoted-pattern
                       |  quoted-pattern
                       ;
 unquoted-pattern     ::= (unquoted-text | placeable | block-text)+;
-quoted-pattern       ::= '"' (quoted-text | placeable)+ '"';
-unquoted-text        ::= ([^{] | '\{')*;
-quoted-text          ::= ([^{"] | '\{' | '\"')*;
+quoted-pattern       ::= '"' (quoted-text | placeable)* '"';
+unquoted-text        ::= ([^{] | '\{')+;
+quoted-text          ::= ([^{"] | '\{' | '\"')+;
 block-text           ::= NL __ '|' unquoted-pattern;
 
 placeable            ::= '{' __ placeable-list __ '}';

--- a/grammar.ebnf
+++ b/grammar.ebnf
@@ -17,7 +17,7 @@ number               ::= [0-9]+ ('.' [0-9]+)?;
 member               ::= '*'? '[' keyword ']' __ pattern NL;
 
 message              ::= identifier __ '=' __ (value | trait-list);
-value                ::= pattern;
+value                ::= pattern trait-list?;
 trait-list           ::= NL (__ trait NL)+ __ trait?;
 trait                ::= member;
 


### PR DESCRIPTION
Previously, an empty string was valid for both unquoted-text and
quoted-text. While this was fine for quoted-text (it's surrounded by
quotes), this didn't work work for unquoted-text as this would make an
empty string a valid unquoted-pattern (and so also a valid pattern and
for a valid value). Finally this makes

`identifier =`

a valid message. This disagrees with the current FTL tinker
implementation.

Quoted-text has been updated to retain the symmetry with unquoted-text.
Quoted-pattern has been updated so that

`identifier = ""`

is still a valid message.
