### PR TITLE
Allow whitespace around section headers

### DIFF
--- a/grammar.ebnf
+++ b/grammar.ebnf
@@ -5,16 +5,23 @@ entry                ::= comment
                       ;
 
 comment              ::= '#' .*;
-section              ::= '[[' keyword ']]';
+section              ::= '[[' __ keyword __ ']]';
+
 __                   ::= [ \t]*;
 NL                   ::= [\r\n]+;
+identifier-head      ::= [a-zA-Z_.?-];
+identifier-tail      ::= [a-zA-Z0-9_.?-];
+keyword-head         ::= [^=|#/{}\[\]()0-9];
+keyword-tail         ::= [^=|#/{}\[\]() ];
+keyword-last         ::= [^=|#/{}\[\]()];
 
-identifier           ::= [a-zA-Z_.?-] ([a-zA-Z0-9_.?-])*;
+identifier           ::= identifier-head (identifier-tail)*;
 variable             ::= '$' identifier;
-keyword              ::= [^=|#{}\[\]()]+;
+keyword              ::= keyword-head (keyword-tail* keyword-last)?
 builtin              ::= [A-Z_.?-]+;
 number               ::= [0-9]+ ('.' [0-9]+)?;
-member               ::= '*'? '[' keyword ']' __ pattern NL;
+member               ::= '*'? '[' member-key ']' __ pattern NL;
+member-key           ::= number | (identifier '/')? keyword;
 member-list          ::= NL member+;
 
 message              ::= identifier __ '=' __ (pattern | pattern member-list | member-list);

--- a/grammar.ebnf
+++ b/grammar.ebnf
@@ -9,15 +9,10 @@ section              ::= '[[' __ keyword __ ']]';
 
 __                   ::= [ \t]*;
 NL                   ::= [\r\n]+;
-identifier-head      ::= [a-zA-Z_.?-];
-identifier-tail      ::= [a-zA-Z0-9_.?-];
-keyword-head         ::= [^=|#/{}\[\]()0-9];
-keyword-tail         ::= [^=|#/{}\[\]() ];
-keyword-last         ::= [^=|#/{}\[\]()];
 
-identifier           ::= identifier-head (identifier-tail)*;
+identifier           ::= [a-zA-Z_.?-] ([a-zA-Z0-9_.?-])*;
 variable             ::= '$' identifier;
-keyword              ::= keyword-head (keyword-tail* keyword-last)?
+keyword              ::= [a-zA-Z_.?-] ([a-zA-Z0-9_.?- ]* [a-zA-Z0-9_.?-])?;
 builtin              ::= [A-Z_.?-]+;
 number               ::= [0-9]+ ('.' [0-9]+)?;
 member               ::= '*'? '[' member-key ']' __ pattern NL;


### PR DESCRIPTION
Fixes #5. @zbraniecki -- this implements the changes we talked about last week to characters allowed in keywords, including white-space. Note that currently the l20n.js parser doesn't allow non-Latin characters in keywords.  Should we update the spec here for now?
