### PR TITLE
add (optional) whitespace to member at its start

### DIFF
--- a/grammar.ebnf
+++ b/grammar.ebnf
@@ -15,7 +15,7 @@ variable             ::= '$' identifier;
 keyword              ::= [a-zA-Z_.?-] ([a-zA-Z0-9_.?- ]* [a-zA-Z0-9_.?-])?;
 builtin              ::= [A-Z_.?-]+;
 number               ::= [0-9]+ ('.' [0-9]+)?;
-member               ::= '*'? '[' member-key ']' __ pattern NL;
+member               ::= __ '*'? '[' member-key ']' __ pattern NL;
 member-key           ::= number | (identifier '/')? keyword;
 member-list          ::= NL member+;
 


### PR DESCRIPTION
This PR adds optional whitespace in front of a member, as I guess that's already expected anyhow?

Given the following example (taken form: http://l20n.org/learn/variants):

```ftl
brandName =
 *[nominative] Aurora
  [genitive] Aurore
  [dative] Aurori
  [accusative] Auroro
  [locative] Aurori
  [instrumental] Auroro
```

It can be seen that we clearly expect an indention (1 and 2 spaces in this example) here,
and thus this should be part of the grammar specification IMHO, as this is what implementations are based on, I think?